### PR TITLE
ci: publish containers to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,28 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
+  call-common-ci:
+    uses: its-the-vibe/.github/.github/workflows/common-ci.yaml@main
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: make build
-
-      - name: Test
-        run: make test
-
-      - name: Lint
-        run: make lint
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /build
 
@@ -7,14 +10,16 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY main.go ./
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o finalcountdown .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o finalcountdown .
 
-# Runtime stage — minimal scratch image
-FROM scratch
+# Runtime stage (distroless)
+FROM gcr.io/distroless/static-debian13:nonroot
 
 COPY --from=builder /build/finalcountdown /finalcountdown
 # COPY static/ /static/
 
 EXPOSE 8080
+
+USER nonroot:nonroot
 
 ENTRYPOINT ["/finalcountdown"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
     build: .
+    image: ghcr.io/its-the-vibe/finalcountdown:latest
+    pull_policy: always
     ports:
       - "${PORT:-8080}:8080"
     volumes:


### PR DESCRIPTION
## Summary
- Build cross-platform static binary using `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args
- Switch runtime from `scratch` to `gcr.io/distroless/static-debian13:nonroot` (removes CA cert copy)
- Add `USER nonroot:nonroot` instruction
- Update Compose to use GHCR image with `pull_policy: always`
- Delegate CI/CD to the shared organisation workflow